### PR TITLE
Change event auth sent in message payload

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1490,7 +1490,7 @@ class Channel(TembaModel):
         payload['content'] = text
 
         if channel.secret is not None:
-            payload['event_auth'] = {"Authorization": "Token %s" % channel.secret}
+            payload['event_auth_token'] = channel.secret
 
         if is_ussd:
             session = USSDSession.objects.get_session_with_status_only(msg.session_id)

--- a/temba/channels/tests.py
+++ b/temba/channels/tests.py
@@ -9365,8 +9365,8 @@ class JunebugTest(JunebugTestMixin, TembaTest):
 
             # manually send it off
             self.channel.send_message(dict_to_struct('MsgStruct', msg.as_task_json()))
-            self.assertEqual(mock.call_args[1]['json']['event_auth'],
-                             {"Authorization": "Token UjOq8ATo2PDS6L08t6vlqSoK"})
+            self.assertEqual(mock.call_args[1]['json']['event_auth_token'],
+                             "UjOq8ATo2PDS6L08t6vlqSoK")
 
 
 class MbloxTest(TembaTest):


### PR DESCRIPTION
When building the Junebug side of this feature I decided to pass around the token rather than the whole auth header