### PR TITLE
Fix USSD session lookup again

### DIFF
--- a/temba/channels/handlers.py
+++ b/temba/channels/handlers.py
@@ -7,6 +7,7 @@ import json
 import pytz
 import requests
 import six
+import time
 import magic
 import xml.etree.ElementTree as ET
 
@@ -2079,8 +2080,7 @@ class JunebugHandler(BaseChannelHandler):
 
                 message_date = datetime.strptime(data['timestamp'], "%Y-%m-%d %H:%M:%S.%f")
                 gmt_date = pytz.timezone('GMT').localize(message_date)
-                # Use a session id if provided, otherwise fall back to using the `from` address as the identifier
-                session_id = channel_data.get('session_id') or data['from']
+                session_id = '%s.%s' % (data['from'], int(time.mktime(message_date.timetuple())))
 
                 session = USSDSession.handle_incoming(channel=channel, urn=data['from'], content=data['content'],
                                                       status=status, date=gmt_date, external_id=session_id,

--- a/temba/ussd/tests.py
+++ b/temba/ussd/tests.py
@@ -3,10 +3,11 @@ from __future__ import unicode_literals
 
 import json
 import six
+import time
 import uuid
 
 from datetime import datetime, timedelta
-from mock import patch
+from mock import patch, Mock
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -23,6 +24,9 @@ from temba.flows.models import FlowRun
 from temba.utils import dict_to_struct
 
 from .models import USSDSession
+
+mock_time = Mock()
+mock_time.return_value = time.mktime(datetime(2017, 6, 21).timetuple())
 
 
 class USSDSessionTest(TembaTest):
@@ -855,6 +859,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
         self.assertEquals(inbound_msg.direction, INCOMING)
 
+    @patch('time.mktime', mock_time)
     def test_receive_with_session_id(self):
         from temba.ussd.models import USSDSession
 
@@ -866,8 +871,8 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         # load our message
         inbound_msg, outbound_msg = Msg.objects.all().order_by('pk')
         self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
-        self.assertEquals(outbound_msg.session.external_id, 'session-id')
-        self.assertEquals(inbound_msg.session.external_id, 'session-id')
+        self.assertEquals(outbound_msg.session.external_id, '+27123456789.1498003200')
+        self.assertEquals(inbound_msg.session.external_id, '+27123456789.1498003200')
 
     def test_receive_ussd_no_session(self):
         from temba.channels.handlers import JunebugHandler


### PR DESCRIPTION
This comes from https://github.com/praekeltfoundation/rapidpro/pull/4 which was lost in the merge.