### PR TITLE
Mark initial USSD message as handled

### DIFF
--- a/temba/flows/models.py
+++ b/temba/flows/models.py
@@ -1529,6 +1529,9 @@ class Flow(TembaModel):
         if flow_start:  # pragma: needs cover
             flow_start.update_status()
 
+        if start_msg:
+            Msg.mark_handled(start_msg)
+
         return runs
 
     def start_call_flow(self, all_contact_ids, start_msg=None, extra=None, flow_start=None, parent_run=None):

--- a/temba/ussd/tests.py
+++ b/temba/ussd/tests.py
@@ -16,7 +16,8 @@ from django_redis import get_redis_connection
 from temba.channels.models import Channel
 from temba.channels.tests import JunebugTestMixin
 from temba.contacts.models import Contact, TEL_SCHEME
-from temba.msgs.models import WIRED, MSG_SENT_KEY, SENT, Msg, INCOMING, OUTGOING, USSD, DELIVERED, FAILED
+from temba.msgs.models import (WIRED, MSG_SENT_KEY, SENT, Msg, INCOMING, OUTGOING, USSD, DELIVERED, FAILED,
+                               HANDLED)
 from temba.tests import TembaTest, MockResponse
 from temba.triggers.models import Trigger
 from temba.flows.models import FlowRun
@@ -854,6 +855,7 @@ class JunebugUSSDTest(JunebugTestMixin, TembaTest):
         self.assertEquals(outbound_msg.response_to, inbound_msg)
         self.assertEquals(outbound_msg.session.status, USSDSession.TRIGGERED)
         self.assertEquals(inbound_msg.direction, INCOMING)
+        self.assertEquals(inbound_msg.status, HANDLED)
 
     def test_receive_with_session_id(self):
         from temba.ussd.models import USSDSession


### PR DESCRIPTION
When a user dials a USSD line we create a blank message because we need to populate the `reply_to` field with something when we send a reply. This message is created with a `PENDING` status and which causes the unhandled flow to activate.

This PR changes the status to `HANDLED` in `start_ussd_flow`.