### PR TITLE
Send reply_to for sms + test

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1449,6 +1449,9 @@ class Channel(TembaModel):
                 'continue_session': session and not session.should_end or False,
             }
         else:
+            if msg.response_to_id:
+                payload['reply_to'] = Msg.objects.values_list('external_id', flat=True).filter(pk=msg.response_to_id).first()
+
             payload['from'] = channel.address
             payload['to'] = msg.urn_path
 


### PR DESCRIPTION
Having the reply_to is valuable for more things than just USSD.
It allows external applications to maintain context and for
Junebug to maintain affinity on things other than to_addr / from_addr.