### PR TITLE
Remove account creation form if signups disabled

### DIFF
--- a/temba/public/tests.py
+++ b/temba/public/tests.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+import copy
+
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from smartmin.tests import SmartminTest, _CRUDLTest
@@ -17,6 +20,15 @@ class PublicTest(SmartminTest):
         home_url = reverse('public.public_index')
         response = self.client.get(home_url, follow=True)
         self.assertEqual(response.request['PATH_INFO'], '/')
+
+        # check signup form displayed by default
+        self.assertContains(self.client.get(home_url), "Create Account")
+
+        # check signup form not displayed if signups unavailable
+        branding = copy.deepcopy(settings.BRANDING)
+        branding['rapidpro.io']['allow_signups'] = False
+        with self.settings(BRANDING=branding):
+            self.assertNotContains(self.client.get(home_url), "Create Account")
 
         # try to create a lead from the homepage
         lead_create_url = reverse('public.lead_create')

--- a/temba/public/views.py
+++ b/temba/public/views.py
@@ -31,6 +31,7 @@ class IndexView(SmartTemplateView):
         context = super(IndexView, self).get_context_data(**kwargs)
         context['thanks'] = 'thanks' in self.request.GET
         context['errors'] = 'errors' in self.request.GET
+        context['allow_signups'] = self.request.branding.get('allow_signups', True)
         if context['errors']:
             context['error_msg'] = urlparse.parse_qs(context['url_params'][1:])['errors'][0]
 

--- a/templates/public/public_index.haml
+++ b/templates/public/public_index.haml
@@ -47,19 +47,21 @@
           {{ brand.description }}
 
     .row
-      #lead-form
-        %form{action:'{% ssl_brand_url "public.lead_create" %}', method:'POST'}
-          -csrf_token
+      {% if branding.allow_signups %}
+        #lead-form
+          %form{action:'{% ssl_brand_url "public.lead_create" %}', method:'POST'}
+            -csrf_token
 
-          %fieldset
-            .control-group
-              .controls
-                %nobr
-                  %input.controls{'type':"text", 'name':"email", 'placeholder':"Enter your email.."}
-                  %button.btn.btn-success{type:"submit"}
-                    -trans "Create Account"
-        -if errors
-          %p.text-error {{error_msg}}
+            %fieldset
+              .control-group
+                .controls
+                  %nobr
+                    %input.controls{'type':"text", 'name':"email", 'placeholder':"Enter your email.."}
+                    %button.btn.btn-success{type:"submit"}
+                      -trans "Create Account"
+          -if errors
+            %p.text-error {{error_msg}}
+      {% endif %}
 
     -if not thanks
       %br.clearfix{clear:"both"}

--- a/templates/public/public_index.haml
+++ b/templates/public/public_index.haml
@@ -52,7 +52,7 @@
           {{ brand.description }}
 
     .row
-      {% if branding.allow_signups %}
+      -if allow_signups
         #lead-form
           %form{action:'{% ssl_brand_url "public.lead_create" %}', method:'POST'}
             -csrf_token
@@ -66,9 +66,8 @@
                       -trans "Create Account"
           -if errors
             %p.text-error {{error_msg}}
-      {% else %}
+      -else
         #spacer
-      {% endif %}
 
     -if not thanks
       %br.clearfix{clear:"both"}

--- a/templates/public/public_index.haml
+++ b/templates/public/public_index.haml
@@ -38,6 +38,11 @@
           }
         }
 
+        #spacer {
+          padding-top:63px;
+          background-color: #0c6596;
+        }
+
     {% endlessblock %}
 
 -block post-header
@@ -61,6 +66,8 @@
                       -trans "Create Account"
           -if errors
             %p.text-error {{error_msg}}
+      {% else %}
+        #spacer
       {% endif %}
 
     -if not thanks


### PR DESCRIPTION
If the setting to allow signups is off then don't display the form for users to create accounts (since it doesn't do anything anyway)
Added a blue spacer element to maintain the appearance of the page.